### PR TITLE
Example on Viterbi & Viterbi phase correction

### DIFF
--- a/library/optics/OpticalHybrid_v2.m
+++ b/library/optics/OpticalHybrid_v2.m
@@ -1,0 +1,102 @@
+%> @filt OpticalHybrid_v1.m
+%> @brief Passive part of an optical hybrid
+%>
+%> @class OpticalHybrid_v1
+%> @brief Passive part of an optical hybrid
+%> 
+%>  @ingroup physModels
+%>
+%> Simple 2x4 MMI model.  Converts input field to single from double due to
+%> memory concerns.
+%>
+%> Signal inputs: 2
+%>      -For conventional I-Q definitions, signal goes to input 1, LO to input 2
+%> 
+%> Signal outputs: 4
+%>       -Outputs 1 and 2 are in-phase (I+ and I-, respectively)
+%>       -Outputs 3 and 4 are quadrature (Q+ and Q-, respectively)
+%>
+%> @author Molly Piels
+%> @version 1
+classdef OpticalHybrid_v2 < unit
+
+    
+    properties
+        
+        %> Optical hybrid phase angle
+        phase_angle = pi/2; 
+        
+        %> Number of input arguments
+        nInputs = 2; 
+        %> Number of output arguments
+        nOutputs = 4; 
+    end
+    
+    methods
+        
+        %>  @brief Class constructor
+        %>
+        %>  Class constructor
+        %> 
+        %> Example:
+        %> @code
+        %> hybrid = OpticalHybrid_v1(struct('phase_angle', pi/2));
+        %> @endcode
+        %>
+        %> @param param.phase_angle hybrid phase angle
+        function obj = OpticalHybrid_v2(params)
+            setparams(obj,params);
+        end
+        
+        %>  @brief Traverse function
+        %>
+        %>  Applies frequency shift to LO, then mixes LO with signal
+        %> coherently
+        %>
+        %> @param sig input signal
+        %> @param lo input local oscillator (swapping LO and signal swaps I and Q)
+        %>
+        %> @retval out1 I+
+        %> @retval out2 I-
+        %> @retval out3 Q+
+        %> @retval out4 Q-
+        %> @retval results no results
+        function [out1,out2,out3,out4] = traverse(obj,sig,lo)
+            phase = exp(1j*obj.phase_angle);
+            
+            %FIXME
+            %MEMORY
+            Elo = single(getScaled(lo));
+            
+            % LO setting
+            df = lo.Fc-sig.Fc;
+            Elo = Elo(1:sig.L,:); % Adjust LO signal length
+            t = (1:sig.L)'/sig.Fs;
+            Elo = bsxfun(@times,Elo,exp(2j*pi*df*t)); % Adjust LO frequency
+            clear('t'); %MEMORY
+            
+            % Power, noise, and SNR tracking
+            Psig = [sig.PCol];
+            PLO = [lo.PCol];
+            
+            P_out = Psig + PLO;
+            
+
+            
+            % Generate outputs (power scaled by 4, a hybrid is a 1x4
+            % splitter)
+            out1 = signal_interface((getScaled(sig)+Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out/4, 'Fc', sig.Fc));
+            out2 = signal_interface((getScaled(sig)-Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out/4, 'Fc', sig.Fc));
+            out3 = signal_interface((getScaled(sig)+phase*Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out/4, 'Fc', sig.Fc));
+            out4 = signal_interface((getScaled(sig)-phase*Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out/4, 'Fc', sig.Fc));
+ 
+            %             OLD CONVENTION
+%             out1=signal_interface((Esig+Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out, 'Fc', sig.Fc));
+%             out2=signal_interface((Esig-Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out, 'Fc', sig.Fc));
+%             out3=signal_interface((Esig-phase*Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out, 'Fc', sig.Fc));
+%             out4=signal_interface((Esig+phase*Elo)/2,struct('Fs',sig.Fs,'Rs',sig.Rs, 'P', P_out, 'Fc', sig.Fc));            
+        end
+        
+    end
+    
+end

--- a/library/rx/BalancedPair_v2.m
+++ b/library/rx/BalancedPair_v2.m
@@ -1,0 +1,138 @@
+%> @file BalancedPair_v1.m
+%> @brief Balanced pair model
+%> 
+%> @class BalancedPair_v1
+%> @brief Balanced photodiode pair model
+%> 
+%>  @ingroup physModels
+%>
+%> Balanced pair model.  Includes responsivity, finite common-mode
+%> rejection ratio, 3dB bandwidth, thermal, and shot noise contributions.
+%> Has a property for maximum input power, but signal clipping is not
+%> implemented.
+%>
+%> @author Molly Piels
+%> @version 1
+classdef BalancedPair_v2 < unit
+    
+    properties
+        %> Responsivity (A/W)
+        R;
+        %> Common-mode rejection ratio (dB)
+        CMRR; 
+        %> 3dB cutoff frequency (Hz)
+        f3dB;  
+        %> thermal resistance (ohm)
+        Rtherm; 
+        %> maximum input power (NOT USED)
+        Pmax;   
+        
+        %> Temperature (K)
+        T = 290;                
+        
+        %> Number of input arguments
+        nInputs = 2;  
+        %> Number of output arguments
+        nOutputs = 1; 
+    end
+    
+    methods
+        
+        
+        %>  @brief Class constructor
+        %>
+        %>  Class constructor
+        %>
+        %>  Example:
+        %>  @code
+        %>  BPD = BalancedPair_v1(struct('R', 1, 'CMRR', 50, 'f3dB', 28e9, 'Rtherm', 50));
+        %>  @endcode
+        %>
+        %> @param param.R Responsivity (A/W)
+        %> @param param.f3dB electrical 3dB bandwidth (Hz)
+        %> @param param.Rtherm resistance for thermal noise calculation (ohm)
+        %> @param param.CMRR common-mode rejection ratio (dB) (default infinite)
+        %>
+        %> @retval BalancedPair object
+        function obj = BalancedPair_v2(param)
+            % Intialize parameters
+            obj.R = param.R;
+            obj.f3dB = param.f3dB;
+            obj.Rtherm = param.Rtherm;
+            if isfield(param, 'CMRR')
+                obj.CMRR = param.CMRR;            
+            else
+                obj.CMRR = inf;
+            end
+            if isfield(param, 'Pmax')
+                obj.Pmax = param.Pmax;
+            else
+                obj.Pmax = inf;
+            end
+            
+        end
+        
+        
+        %>  @brief Traverse function
+        %>
+        %>  Performs square-law detection on both input signals, then
+        %>  subtracts with finite CMRR, then adds noise, then low-pass
+        %>  filters.
+        %>  
+        %> @param in1 input signal 1
+        %> @param in2 input signal 2
+        %>
+        %> @retval out BPD output
+        %> @retval results.Rmix mixing ratio from CMRR calculation
+        function out = traverse(obj,in1, in2)
+            
+            % All following operations are performed on 'normalized
+            % photocurrent': abs(whatever is in the signal's waveform)^2
+            
+            % save for later - inputs get overwritten
+            Ps_an = in1.P.Ps('W')+in2.P.Ps('W');
+            Pn_an =in1.P.Pn('W')+in2.P.Pn('W');
+            Pin_an = Ps_an+Pn_an;  
+            
+            % square-law detection and polarization addition
+            in1f = getRaw(in1);
+            in2f = getRaw(in2);
+%             in1f = getScaled(in1);
+%             in2f = getScaled(in2);
+            in1f = in1f.*conj(in1f);
+            in2f = in2f.*conj(in2f);
+            in1f = real(in1f);      
+            in2f = real(in2f);      
+
+            % subtraction with finite CMRR
+            % also, responsivity
+            R_mix=0.5/(10^(obj.CMRR/10));
+            outmix = obj.R*(in1f*(R_mix+1)+in2f*(R_mix-1));
+            %track output power and SNR
+            Ps_out = pwr.meanpwr(outmix)/(1+Pn_an/Ps_an);
+            Pn_out1 = Ps_out*Pn_an/Ps_an;
+            
+            %Add noise currents
+            Pnshot = 2*const.q*obj.R*Pin_an*obj.f3dB;
+            Pntherm = 4*const.kB*obj.T/obj.Rtherm*obj.f3dB;
+            Pn_out = Pn_out1+Pnshot+Pntherm;
+            noise_sig=wgn(length(outmix), 1, Pnshot, 'linear', 'real')+wgn(length(outmix), 1, Pntherm, 'linear', 'real');
+            outn = outmix + noise_sig;
+%             outn = outmix;
+            
+            % low-pass filtering
+            [b_lp,a_lp] = butter(6, 2*obj.f3dB/(in1.Fs));
+            outf = filter(b_lp,a_lp,outn);
+%             outf = outn;
+            
+            out = signal_interface(outf, struct('Fs',in1.Fs,'Rs',in1.Rs, 'P', ...
+                pwr(10*log10(Ps_out/Pn_out),{Ps_out,'W'}), 'Fc', in1.Fc-in2.Fc ));
+            
+            % save mixing ratio
+            obj.results = struct('Rmix', R_mix);
+            
+        end
+        
+    end
+    
+end

--- a/library/rx/CoherentFrontend_single_pol_v1.m
+++ b/library/rx/CoherentFrontend_single_pol_v1.m
@@ -1,0 +1,93 @@
+%> @file CoherentFrontend_single_pol_v1.m
+%> @brief coherent front-end with polarization diversity
+%>
+%> @class CoherentFrontend_single_pol_v1
+%> @brief coherent front-end with polarization diversity
+%> 
+%>  @ingroup physModels
+%>
+%> Coherent front-end module.  Consists of:
+%> - local oscillator (Laser_v1)
+%> - optical hybrid (OpticalHybrid_v1)
+%> - two  balanced pairs (BalancedPair_v1)  
+%> See relevant class files for model details.
+%>
+%> The two outputs are, in order, I, Q
+%>
+%> @author Santiago Echeverri
+%> @version 1
+classdef CoherentFrontend_single_pol_v1 < module
+    
+    properties
+        %> Number of input arguments
+        nInputs = 1; 
+        %> Number of output arguments
+        nOutputs = 2;
+    end
+    
+    methods
+        
+        %>  @brief Class constructor
+        %> 
+        %>  Class constructor
+        %>
+        %>  Example:
+        %>  @code
+        %>  %% Specify parameters
+        %>  % LO has a center frequency 50 MHz above signal, 100kHz linewidth, and 5 dBm output power.
+        %>  foffset = 50e6;
+        %>  LOparam = struct('Power', pwr(150, {5, 'dBm'}), 'linewidth', 100e3, 'Fc', const.c/signal_wavelength+foffset);
+        %>  % Balanced pair(s) have 1A/W, 50dB CMRR, 36 GHz bandwidth
+        %>  BPDparam = struct('R', 1, 'CMRR', 50, 'f3dB', 36e9, 'Rtherm', 50);
+        %>  %% Rename parameters
+        %>  param.LO = LOparam;
+        %>  % align local oscillator to 45 degrees at input of PBS
+        %>  param.hyb.phase_angle = pi/2;
+        %>  %% Construct object
+        %>  CohFrontend = CoherentFrontend_single_pol_v1(param)
+        %>  @endcode
+        %> 
+        %> @param param.LO local oscillator parameters
+        %> @param param.hyb optical hybrid parameters
+        %> @param param.bpd balanced pair parameters
+        %>
+        %> @retval CoherentFrontend object
+        function obj=CoherentFrontend_single_pol_v1(param)
+            %% Laser_v1 tweak
+            % Force Laser_v1 to work in mode where noise length is
+            % dictated by the input signal
+            param.LO.nInputs = 1;
+            if isfield(param,'draw')
+                obj.draw = param.draw;
+            end
+            % Remove unnecessary fields
+            for field={'Fs','Rs','Lnoise'}
+                if isfield(param.LO,field)
+                    param.LO = rmfield(param.LO, field);
+                end
+            end
+            
+            %% Components
+            branch = BranchSignal_v1(2);
+            lo =  Laser_v1(param.LO);
+            hyb = OpticalHybrid_v2(param.hyb); %x-pol
+            bpd1 = BalancedPair_v2(param.bpd);
+            bpd2 = BalancedPair_v2(param.bpd);
+
+            %external connections on input
+            obj.connectInputs({branch}, 1);
+            
+            %internal connections
+            branch.connectOutputs({hyb lo}, [1 1]);
+            lo.connectOutputs(hyb, 2);
+            hyb.connectOutputs({bpd1 bpd1 bpd2 bpd2}, [1 2 1 2]);
+            
+            %external connections at output
+            bpd1.connectOutputs(obj.outputBuffer,1);
+            bpd2.connectOutputs(obj.outputBuffer,2);
+            
+            exportModule(obj);
+        end        
+    end
+    
+end

--- a/library/rx/DSP/BERT_v1.m
+++ b/library/rx/DSP/BERT_v1.m
@@ -234,8 +234,12 @@ classdef BERT_v1 < unit
         %> @param refSig reference PRBS
         function traverse(obj, sig, refSig)
             % Obtain prbs
-            if obj.nInputs==2
+           if obj.EnableCounter && obj.nInputs==2
+                if any(refSig>1) % The reference signal has a symbol with value 2
+                    obj.TxData = refSig;
+                else % The reference signal is a prbs signal.
                 obj.TxData = obj.obtainPRBS(refSig);
+                end
             end
             % Obtain input data
             if sig.Nss > 1

--- a/library/rx/DSP/VITERBI_CPR_v1.m
+++ b/library/rx/DSP/VITERBI_CPR_v1.m
@@ -1,0 +1,243 @@
+%> @file VITERBI_CPR_v1
+%> @brief contains implementation of Feed Forward Non-Decision-Aided CPR 
+%>
+%> @class VITERBI_CPR_v1
+%> @brief Viterbi & Viterbi NDA carrier phase estimation.
+%> 
+%> @ingroup Metro Access & Short Range Communications
+%> 
+%> This class implements a non-decision-aided (NDA) feedforward carrier 
+%> phase estimation (CPA) algorithm. The carrier recovery is based on the 
+%> implementation of the Viterbi & Viterbi algorithm followed by 
+%> differential demodulation as discussed in references [1,2]. 
+%> Reference [3] is the seminal paper where the algorithm was 
+%> first proposed.
+%> 
+%> The main idea is to detect the uncompensated phase ($\theta_0$) 
+%> of a signal of the form
+%> z_n = \left[ a_n \exp{(j\theta_0)} +m_n \right].
+%> 
+%> Where the original symbols are $a_n$ and the term $m_n$ is noise.
+%> When the modulation format is QPSK the data symbols belong to the set:
+%> 
+%> $\{ exp(j2\pi m/M) | m=0,1,...,M-1\}$
+%> 
+%> The data dependency in $z_n$ is eliminated by taking the detected signal 
+%> to the Mth power and then evaluating the argument. 
+%> Phase estimation is done for blocks of the signal of size N_{vv} under 
+%> the assumpition that the phase change is slow. 
+%> Short block sizes give a more accurate representation of phase noise 
+%> variation and large block sizes give a better compensation of amplitude 
+%> noise.
+%>
+%> After exponentiation an M-fold ambiguity occurs on the phase.
+%> There are M different values of m that satisfy 
+%>  $\exp{(\hat{\theta}+2\pi m /M)M} =  \exp{(\hat{\theta})M} $
+%> Diferential precoding is generally used to adresses the correction of 
+%> the ambiguity, and both decoding and phase unwrapping are implemented 
+%> here.
+%> 
+%> The phase that is stored has been unwrapped using the algorithm
+%> described in [4] p56 eq.3.52.
+%>
+%> Example:
+%> @code
+%>      Pending
+%> @endcode
+%> 
+%> "plot" function plots demodulated phase
+%>
+%> References: 
+%> [1] Ly-Gagnon, D. S., Tsukamoto, S., Katoh, K., & Kikuchi, K. (2006). 
+%>     "Coherent detection of optical quadrature phase-shift keying signals 
+%>     with carrier phase estimation."
+%>     Journal of Lightwave Technology, 24(1), 12.
+%> [2] Goldfarb, G., & Li, G. (2006). 
+%>     "BER estimation of QPSK homodyne detection with carrier phase 
+%>      estimation using digital signal processing."
+%>     Optics express, 14(18), 8043-8053.
+%> [3] Viterbi, A. (1983). 
+%>     "Nonlinear estimation of PSK-modulated carrier phase with 
+%>      application to burst digital transmission." 
+%>      IEEE Transactions on Information theory, 29(4), 543-551.
+%> [4] J. C. M. Diniz and A. C. Bordonalli, “Estimador de desvio de 
+%>     frequência para receptores ópticos coerentes digitais,” Dissertação 
+%>     de Mestrado, 2013.
+%>
+%> @author Santiago Echeverri 
+
+classdef VITERBI_CPR_v1 < unit
+    
+    properties
+        nInputs = 1;
+        nOutputs = 1;
+        
+        %> Main control parameters: N
+        %> Number of precursors and post cursors used for the averaging
+        %> window.
+        N = 11;
+        %> Highest integer number of blocks of size N by which the signal 
+        %> can be divided. 
+        n_blcks;
+        %> Saved phase for x polarization
+        phase_x;
+        %> Saved phase for y polarization
+        % phase_y; %Not used for now
+        %Baud rate (for plotting, taken from input signal)
+        Fb;   
+        %> Other
+        param;
+        %> Frequency offset estimated from the ramp after unwrapping of
+        %> phase
+        f_off = 0;
+    end
+    
+    methods
+        %> @brief Class constructor
+        %> 
+        %> Class constructor - params are saved and checked
+        %>
+        %> @param param structure with loop parameters
+        %>
+        %> @retval obj instance of DDPLL_v1 class
+        function obj = VITERBI_CPR_v1(param)
+            if isfield(param,'N')
+                obj.N = param.N;
+            end
+            if isfield(param,'draw')
+                obj.draw = param.draw;
+            end
+        end
+        
+        %> @brief Travese function
+        %> 
+        %> Parses input, calls carrier recovery, parses output
+        %>
+        %> @param varargin input signal (either 1 for (I+jQ) or 2 for
+        %>        (I,Q)). Dual polarization not yet supported
+        %>
+        %> @retval out signal with phase correction applied
+        function out = traverse(obj, varargin)
+            switch numel(varargin)
+                case 1
+                    sig1 = varargin{1};
+                    if isreal(sig1.getNormalized)
+                        error('Input signal components must be complex valued')
+                    else
+                        sig = sig1;
+                    end
+                case 2
+                    sig1 = varargin{1};
+                    sig2 = varargin{2};
+                    sigmat = [sig1.getNormalized sig2.getNormalized];
+                    if isreal(sigmat(:,1)) && isreal(sigmat(:,2))
+                        sig = sig1.set(complex(sigmat(:,1),sigmat(:,2)));
+                    else
+                        error('When using 2 inputs, they must all be real valued')
+                    end
+            end
+            
+            [out] = obj.viterbi(sig);
+            if obj.draw
+                obj.plot();
+            end
+        end
+        
+        %> @brief Main PLL
+        %>
+        %> Performs carrier recovery
+        %>
+        %> @param Ein input signal 
+        %>
+        %> @retval Eout signal with phase correction applied
+        function [Eout] = viterbi(obj, Ein)
+            %% Initialization
+            obj.Fb = Ein.Rs; Fs = Ein.Fs;
+            obj.param.Ts = 1/Ein.Rs;
+            
+            sig = Ein.getRaw;
+            
+            L = int32(Ein.L);
+            obj.N = int32(obj.N);
+            obj.n_blcks = idivide(L,2*obj.N+1,'floor'); %Number of full sized blocks
+                       
+            % Center elements of each block of size 2*N+1.
+            blck_indx_vec =  (1:obj.n_blcks)*(2*obj.N+1)-obj.N; 
+            %% Phase extraction and slicing
+            theta = zeros(1,obj.n_blcks);
+            T = angle(sig);
+            blck_indx = 1;
+            for blck_cntr = blck_indx_vec 
+                blck = (blck_cntr-obj.N):(blck_cntr+obj.N);
+                % Phase extraction using the 4th power method
+                theta(blck_indx) = (1/4)*angle(-sum(sig(blck).^4));
+                % Implementation of the phase treshold operator T
+                T(blck) = round(((T(blck) - theta(blck_indx))-pi/4)/(pi/2));
+                blck_indx = blck_indx+1;
+            end
+            
+            %% Differential decoding 
+            d = T; 
+            blck_indx = 1;
+            for blck_cntr = blck_indx_vec 
+                blck     = (blck_cntr-obj.N):(blck_cntr+obj.N-1);
+                blck_p_1 = (blck_cntr-(obj.N-1)):(blck_cntr+obj.N);  %shifted index
+                d(blck) = mod(T(blck_p_1)-T(blck),4);
+                A = @(x)(abs(x)>abs(pi/4))*sign(x);
+                
+                % d is the decoded signal.
+                %   d_{Nb}      =       T_1_Pu2                -       T_Nb_Pu1      + A(\phi_est_Pu2               -  \phi_est_Pu1) |_mod4   
+                if ~isequal(blck_indx,obj.n_blcks)
+                    d(blck_cntr+obj.N) = mod(T(blck_indx_vec(blck_indx+1)-obj.N)-T(blck_cntr+obj.N)+A(theta(blck_indx+1)-theta(blck_indx)),4);
+                else
+                    if isequal(mod(L,2*obj.N+1),0)
+                        d(blck_cntr+obj.N) = mod(T(blck_cntr+obj.N),4);
+                    else
+                        % Case for when the last block is not a full sized block
+                        
+                        N_special = mod(L,2*obj.N+1);% This is the size of the last block            
+                        last_blk = (L-N_special+1):L;
+                        theta_last_blk = (1/4)*angle(-sum(sig(last_blk).^4));
+                        T(last_blk) = round(((T(last_blk) - theta_last_blk)-pi/4)/(pi/2));   
+                        
+                        d(blck_cntr+obj.N) = mod(T(last_blk(1))-T(blck_cntr+obj.N)+A(theta_last_blk-theta(blck_indx)),4);
+                        
+                        d(last_blk) = mod(T((L-N_special):(L-1))-T((L-(N_special-1)):L),4);
+                    end
+                end
+                blck_indx = blck_indx+1;
+            end
+            
+
+            obj.phase_x = theta;
+            
+            Eout = signal_interface(d(1:end-1), struct('Rs', obj.Fb, 'Fs', Fs, 'P', Ein.P, 'Fc', Ein.Fc));
+            
+            
+        end
+        
+        %> @brief Plot results
+        %>
+        %> Plots phase as a function of time, estimates frequency offset
+        function plot(obj)
+            figure(2833);
+            L = obj.n_blcks;
+            plot(0:L-1,obj.phase_x);
+            set(gcf,'name','Wrapped phase noise')
+            L_est = min(1e4,numel(obj.phase_x));
+            est_f_off = (obj.phase_x(end)-obj.phase_x(end-L_est+1))/(2*pi*L_est)*obj.Fb;
+            fprintf('Estimated frequency offset %0.0f MHz\n',est_f_off/1e6);    
+            obj.f_off=est_f_off/1e6;
+            %% Phase unwrap
+            for ii = 2:length(obj.phase_x)
+                obj.phase_x(ii) = obj.phase_x(ii)+floor(0.5+(obj.phase_x(ii-1)-obj.phase_x(ii))/(2*pi/4))*2*pi/4;
+            end
+            figure(2834);
+            plot(0:L-1,obj.phase_x);
+            set(gcf,'name','Unwrapped phase noise')
+            
+            
+        end
+        
+    end
+end

--- a/library/tx/IQ_single_pol_v1.m
+++ b/library/tx/IQ_single_pol_v1.m
@@ -1,0 +1,81 @@
+%> @file IQ_single_pol_v1.m
+%> @brief IQ modulator model
+%> 
+%> @class IQ_single_pol_v1
+%> @brief  IQ modulator model
+%>
+%> Takes 3 signal_interfaces (2 with data and a laser) and puts it in to one
+%> with 1 complex column plus phase noise and carrier frequency of the laser
+%> If 'mode' is set to 'simple', it takes 3 signals (2 with the real
+%> data and the laser)
+%> If 'mode' is set to 'complex', it takes 2 signals (1 with a complex
+%> colum and the other with laser)
+%>
+%> @author Santiago Echeverri
+classdef IQ_single_pol_v1 < unit
+    
+    properties
+        nInputs=3;
+        nOutputs=1;
+        IQgain_imbalance;
+        Vamp;
+        Vb;
+        Vpi;
+        IQphase;
+        f_off;
+        
+    end
+    
+    methods
+        function obj = IQ_single_pol_v1(param)
+%             obj.Vamp = paramdefault(param, 'Vamp', 1*ones(2,1));
+            obj.Vamp = paramdefault(param, 'Vamp', 1*ones(2,1));
+            obj.Vb = paramdefault(param, 'Vb',  5*ones(2,1));
+            obj.Vpi =  paramdefault(param, 'Vpi',  5*ones(2,1));
+            obj.IQphase = paramdefault(param,'IQphase', pi/2);
+            obj.IQgain_imbalance =  paramdefault(param, 'IQgain_imbalance', 0);
+            obj.f_off =  paramdefault(param, 'f_off', 0);
+            mode = paramdefault(param, 'mode', 'simple');
+            if strcmp(mode, 'simple')
+                obj.nInputs = 3;
+            elseif strcmp(mode, 'complex')
+                obj.nInputs = 2;
+            end
+        end
+        function out = traverse(obj,varargin)
+            % Extract params
+            Fs = varargin{1}.Fs;
+            L = varargin{1}.L;
+            switch obj.nInputs
+                case 3
+                    data = [varargin{1}.get varargin{2}.get];
+                    laser = varargin{3};
+                case 2
+                    data = varargin{1}.get;
+                    data = [real(data(:,1)) imag(data(:,1))];
+                    laser = varargin{2};
+            end
+            % Driving signal
+            drive = bsxfun(@times,data,obj.Vamp(:).');
+            % Tx field
+            E_tx = cos(pi/2*bsxfun(@rdivide,bsxfun(@plus,drive,obj.Vb(:).'),obj.Vpi(:).'));
+            % Cross talk terms
+            x_in_x = 10^(-obj.IQgain_imbalance/20);
+            % time vector (f?)
+            f = (0:L-1)'/Fs;
+            % Per polarization power
+            P_pol = laser.P.Ptot('W'); % Convert dBm to W  to get power.
+            % Put together and add phase noise
+            E = sqrt(P_pol)*( sum(bsxfun(@times,E_tx(:,1:2), ...
+                [x_in_x exp(1i*obj.IQphase)]),2) ...
+                ) .* exp(1i*2*pi*f*obj.f_off);
+            E = E.*laser.E(1:length(E));
+%             E = data(:,1) + 1j.*data(:,2);
+            % Generate output signal
+            out = signal_interface(E , struct('Rs', varargin{1}.Rs, 'Fs', varargin{1}.Fs, 'Fc', laser.Fc, 'P', laser.P));
+         end
+        
+    end
+    
+end
+

--- a/setups/_Demo/Examples4_realistic_systems/Ex4_SimplerCoherentBackToBack_w_cpr_ScriptMode.asv
+++ b/setups/_Demo/Examples4_realistic_systems/Ex4_SimplerCoherentBackToBack_w_cpr_ScriptMode.asv
@@ -1,0 +1,206 @@
+% Run a simple coherent transmission example as a script
+%
+% This is a simple "back-to-back" setup with no channel.  However,
+% there is some quantization noise at the transmitter and receiver, as well
+% as normal shot noise and electrical noise in the receiver.
+%
+% This scrip uses a model of single polarization QPSK coherent detection.
+% The state of polarization of the LO is assumed to be aligned with the
+% signal. 
+% The idea is to explore the effects of lasers linewidth and OSNR on the 
+% BER  before and after using phase synchronization algorithms.
+%
+% The phase synchronization algorithm is the 4th power method and has been 
+% implemented as a module called VITERBI_CPR_v1.m.
+%
+
+
+%Initialize
+
+%% General Params
+robochameleon;
+setpref('robochameleon', 'debugMode', 1)        %make sure unit outputs will be available to view
+
+clearall
+close all
+
+%MAIN CONTROLS
+M = 4;     %modulation order
+Rs = 28e9;  %symbol rate
+L = 2^13-1;   %sequence length
+linewidth = 1e5;
+OSNR = 29;
+%% DSO_v1 definition
+% param.dso.only=2;
+param.dso.maxlength=1e4;
+param.dso.enable=1;
+param.dso.mode = 'coherent';
+param.dso.nInputs = 1;
+dso = DSO_v1(param.dso);
+
+param.cb.nInputs = 2;
+param.cb.type = 'simple';
+Combiner_simple = Combiner_v1(param.cb);
+
+%% Signal definition
+constType='QAM';
+constellation = constref(constType, M);
+
+Fs_dso = 80e9;
+Fs = 4*Rs;
+Fc =193.625e12;
+
+% PULSE PATTERN GENERATOR
+param.ppg = struct('order', 15, 'total_length', L, 'Rs', Rs, 'nOutputs', 1, 'levels', [-1 1]);
+ppg = PPG_v1(param.ppg);
+sig_x_c = ppg.traverse();
+
+% DELAY AND NEGATE
+delay1  = Delay_v1(1);
+sig_x_s = delay1.traverse(sig_x_c);
+sig_x_c = sig_x_c.fun1(@(x) - x);
+
+% PULSE SHAPING
+param.ps.samplesPerSymbol = 16;
+param.ps.pulseShape       = 'rz33';
+param.ps.symbolRate       = Rs;
+ps = PulseShaper_v1(param.ps);
+
+% sig_x_c = sig_x_c.fun1(@(x) awgn(x,18));
+% sig_x_s = sig_x_s.fun1(@(x) awgn(x,18));
+
+sig_x_c_us = ps.traverse(sig_x_c);
+sig_x_s_us = ps.traverse(sig_x_s);
+
+%% Scopes on the transmitted signals 
+% dso.traverse(Combiner_simple.traverse(sig_x_c,sig_x_s));
+% name = [get(gcf,'name'),': Transmitted signal after upsampling'];
+% set(gcf,'name',name)
+% dso.traverse(Combiner_simple.traverse(sig_x_c_us,sig_x_s_us));
+% name = [get(gcf,'name'),': Transmitted signal after upsampling'];
+% set(gcf,'name',name)
+
+decimator = Decimate_v1(struct('Nss',1,'draw',0));
+
+%% LASER DEFINITION AND MODULATION
+param.laser = struct('Power', pwr(30, {5, 'dBm'}), 'linewidth', linewidth, ...
+    'Fs', param.ppg.Rs*param.ps.samplesPerSymbol, 'Rs', Rs, 'Fc', Fc, ...
+    'Lnoise', param.ps.samplesPerSymbol*L, 'L', L);
+laser       = Laser_v1(param.laser);
+sig_laser   = laser.traverse();
+param.iq    = struct('mode','simple');
+iq          = IQ_single_pol_v1(param.iq);
+
+sig_x     = iq.traverse(sig_x_c_us, sig_x_s_us, sig_laser);
+
+%% Scope on optical signal after transmitter laser.
+% dso.traverse(Combiner_simple.traverse(sig_x.fun1(@(x) real(x)),sig_x.fun1(@(x) imag(x))));
+% name = [get(gcf,'name'),': Transmitted signal after laser'];
+% set(gcf,'name',name)
+
+%% Channel noise
+param.SNR.OSNR = OSNR;
+snr = OSNR_v1(param.SNR);
+sig_x = snr.traverse(sig_x);
+
+%% COHERENT FRONT END
+% foffset = 3e6;
+foffset = 0e3;
+LOparam = struct('Power', pwr(30, {5, 'dBm'}), 'linewidth', linewidth, 'Fc', Fc+foffset);
+param.coh.LO = LOparam;
+param.coh.draw = 0;
+param.coh.hyb.phase_angle = pi/2;
+BPDparam = struct('R', 1,'f3dB', 4*Rs,'Rtherm', 50);
+param.coh.bpd = BPDparam;
+
+cfe = CoherentFrontend_single_pol_v1(param.coh);
+[I, Q] = cfe.traverse(sig_x);
+
+
+IQ = Combiner_simple.traverse(I, Q);
+
+% time = 0:35.71e-12:35.71e-12*(IQ.L-1);
+% I.fun1(@(x)x.*exp(-1j.*time'));
+% Q.fun1(@(x)x.*exp(-1j.*time'));
+
+dso.traverse(IQ);
+name = [get(gcf,'name'),': Transmitted signal after coherent front end'];
+set(gcf,'name',name)
+
+param.cb2.nInputs = 2;
+param.cb2.type    = 'complex';
+Combiner_complex  = Combiner_v1(param.cb2);
+
+%% Equalization
+
+% param.dsp.eq = struct('type', 'mma', 'h_ortho', true, 'iter', 4, ...
+%     'taps', 13, 'cma_preconv', 10e3, 'equalizer_conv', 20e3, 'mu', 6e-4, ...
+%     'constellation', [constref('QAM',M)],'draw',0);
+% dsp = AdaptiveEqualizer_MMA_RDE_v1(param.dsp.eq);
+
+%% Carrier recovery using Viterbi and Viterbi phase equalization
+param.cpr.vv = struct('N', 10,'draw',1');
+cpr = VITERBI_CPR_v1(param.cpr.vv);
+decoded_symb = cpr.traverse(decimator.traverse(I),decimator.traverse(Q));
+dec_symbs = decoded_symb.getRaw+1;
+p = params(decoded_symb);
+decoded_IQ = signal_interface(exp(1j.*(dec_symbs-1+1/2)*2*pi/4),p);
+
+%% BER TESTER
+sig_x     = Combiner_complex.traverse(sig_x_c.fun1(@(x) - x), sig_x_s.fun1(@(x) - x));
+T         = round((angle(get(sig_x))-(pi/4))/(pi/2));
+sig_diff  = uint16(mod(T(2:end)-T(1:(end-1)),4))+1; 
+sig_bits  = Combiner_simple.traverse(sig_x_c.fun1(@(x) - x), sig_x_s.fun1(@(x) - x));
+bits = get(sig_bits);
+bits(bits==-1) =0;
+symbs = uint16(mod(T,4))+1;
+
+% dso.traverse(sig_bits);
+% name = [get(gcf,'name'),': sig_bits'];
+% set(gcf,'name',name)
+
+param.bert = struct('M', M, 'dimensions', 1,'ConstType','QAM', 'coding', 'bin', 'PostProcessMethod', 'none','DecisionType', 'hard');
+param.bert_prbs = struct('M', M, 'dimensions', 1,'ConstType','QAM', 'coding', 'bin','prbs', gen_prbs(15),'PostProcessMethod', 'none','DecisionType', 'hard');
+bert = BERT_v1(param.bert);
+bert_prbs = BERT_v1(param.bert_prbs);
+% IQ = Combiner_complex.traverse(decimator.traverse(sig_x_c_us), decimator.traverse(sig_x_s_us));
+IQ = Combiner_complex.traverse(decimator.traverse(I), decimator.traverse(Q));
+
+% phase_noise = zeros(L-1,1);
+phase_noise = zeros(L,1);
+% Center elements of each block of size 2*N+1.
+blck_indx_vec =  (1:cpr.n_blcks)*(2*cpr.N+1)-cpr.N; 
+blck_indx = 1;
+for blck_cntr = blck_indx_vec
+    blck = (blck_cntr-cpr.N):(blck_cntr+cpr.N);
+    phase_noise(blck) = cpr.phase_x(blck_indx);
+    blck_indx = blck_indx+1;
+end
+
+
+bert_prbs.traverse(IQ);
+name = [get(gcf,'name'),': Before phase correction'];
+set(gcf,'name',name)
+
+IQ = signal_interface(IQ.getRaw.*exp(-1j*phase_noise),p);
+
+lut  = [4,3,1,2];
+[~,symb_range] = findrange(sig_diff);
+for i=max(1,symb_range.min):symb_range.max
+    idx = sig_diff==i; % Find indices for all symbols i
+    symb(idx) = repmat(lut(i),1,nnz(idx)); % Take value from the LUT
+end
+symb = uint16(symb);
+% symb(5000:5008) = [3,3,3,3,3,3,3,3,3];
+bert.traverse(decoded_IQ,symb');
+name = [get(gcf,'name'),': After phase correction using symbs'];
+set(gcf,'name',name)
+
+bert_prbs.traverse(IQ);
+bert_prbs.traverse(decoded_IQ);
+name = [get(gcf,'name'),': After phase correction using PRBS'];
+set(gcf,'name',name)
+
+
+% coherentLink = setup_simple_coherent_carrier_recovery(param);
+

--- a/setups/_Demo/Examples4_realistic_systems/Ex4_SimplerCoherentBackToBack_w_cpr_ScriptMode.m
+++ b/setups/_Demo/Examples4_realistic_systems/Ex4_SimplerCoherentBackToBack_w_cpr_ScriptMode.m
@@ -1,0 +1,180 @@
+% Run a simple coherent transmission example as a script
+%
+% This is a simple "back-to-back" setup with no channel.
+%
+% This scrip uses a model of single polarization QPSK coherent detection.
+% The state of polarization of the LO is assumed to be aligned with the
+% signal. 
+% The idea is to explore the effects of lasers linewidth and OSNR on the 
+% BER  before and after using phase synchronization algorithms.
+%
+% The phase synchronization algorithm is the 4th power method and has been 
+% implemented as a module called VITERBI_CPR_v1.m.
+%
+
+%Initialize
+
+%% General Parameters
+robochameleon;
+setpref('robochameleon', 'debugMode', 1)        %make sure unit outputs will be available to view
+
+clearall
+close all
+
+%MAIN CONTROLS
+M = 4;     %modulation order
+Rs = 28e9;  %symbol rate
+L = 2^13-1;   %sequence length
+linewidth = 1e5;
+OSNR = 20;
+%% DSO_v1 definition
+% param.dso.only=2;
+param.dso.maxlength=1e4;
+param.dso.enable=1;
+param.dso.mode = 'coherent';
+param.dso.nInputs = 1;
+dso = DSO_v1(param.dso);
+
+param.cb.nInputs = 2;
+param.cb.type = 'simple';
+Combiner_simple = Combiner_v1(param.cb);
+
+%% Signal definition
+constType='QAM';
+constellation = constref(constType, M);
+
+Fs_dso = 80e9;
+Fs = 4*Rs;
+Fc =193.625e12;
+
+% PULSE PATTERN GENERATOR
+param.ppg = struct('order', 15, 'total_length', L, 'Rs', Rs, 'nOutputs', 1, 'levels', [-1 1]);
+ppg = PPG_v1(param.ppg);
+sig_x_c = ppg.traverse();
+
+% DELAY AND NEGATE
+delay1  = Delay_v1(1);
+sig_x_s = delay1.traverse(sig_x_c);
+sig_x_c = sig_x_c.fun1(@(x) - x);
+
+% PULSE SHAPING
+param.ps.samplesPerSymbol = 16;
+param.ps.pulseShape       = 'rz33';
+param.ps.symbolRate       = Rs;
+ps = PulseShaper_v1(param.ps);
+
+sig_x_c_us = ps.traverse(sig_x_c);
+sig_x_s_us = ps.traverse(sig_x_s);
+
+%% Scopes on the transmitted signals 
+% dso.traverse(Combiner_simple.traverse(sig_x_c,sig_x_s));
+% name = [get(gcf,'name'),': Transmitted signal after upsampling'];
+% set(gcf,'name',name)
+% dso.traverse(Combiner_simple.traverse(sig_x_c_us,sig_x_s_us));
+% name = [get(gcf,'name'),': Transmitted signal after upsampling'];
+% set(gcf,'name',name)
+
+decimator = Decimate_v1(struct('Nss',1,'draw',0));
+
+%% LASER DEFINITION AND MODULATION
+param.laser = struct('Power', pwr(30, {5, 'dBm'}), 'linewidth', linewidth, ...
+    'Fs', param.ppg.Rs*param.ps.samplesPerSymbol, 'Rs', Rs, 'Fc', Fc, ...
+    'Lnoise', param.ps.samplesPerSymbol*L, 'L', L);
+laser       = Laser_v1(param.laser);
+sig_laser   = laser.traverse();
+param.iq    = struct('mode','simple');
+iq          = IQ_single_pol_v1(param.iq);
+
+sig_x     = iq.traverse(sig_x_c_us, sig_x_s_us, sig_laser);
+
+%% Scope on optical signal after transmitter laser.
+% dso.traverse(Combiner_simple.traverse(sig_x.fun1(@(x) real(x)),sig_x.fun1(@(x) imag(x))));
+% name = [get(gcf,'name'),': Transmitted signal after laser'];
+% set(gcf,'name',name)
+
+%% Channel noise
+param.SNR.OSNR = OSNR;
+snr = OSNR_v1(param.SNR);
+sig_x = snr.traverse(sig_x);
+
+%% COHERENT FRONT END
+% foffset = 3e6;
+foffset = 0e3;
+LOparam = struct('Power', pwr(30, {5, 'dBm'}), 'linewidth', linewidth, 'Fc', Fc+foffset);
+param.coh.LO = LOparam;
+param.coh.draw = 0;
+param.coh.hyb.phase_angle = pi/2;
+BPDparam = struct('R', 1,'f3dB', 4*Rs,'Rtherm', 50);
+param.coh.bpd = BPDparam;
+
+cfe = CoherentFrontend_single_pol_v1(param.coh);
+[I, Q] = cfe.traverse(sig_x);
+
+IQ = Combiner_simple.traverse(I, Q);
+
+dso.traverse(IQ);
+name = [get(gcf,'name'),': Transmitted signal after coherent front end'];
+set(gcf,'name',name)
+
+param.cb2.nInputs = 2;
+param.cb2.type    = 'complex';
+Combiner_complex  = Combiner_v1(param.cb2);
+
+%% Carrier recovery using Viterbi and Viterbi phase equalization
+
+param.cpr.vv = struct('N', 10,'draw',1');
+cpr = VITERBI_CPR_v1(param.cpr.vv);
+decoded_symb = cpr.traverse(decimator.traverse(I),decimator.traverse(Q));
+dec_symbs = decoded_symb.getRaw+1;
+p = params(decoded_symb);
+decoded_IQ = signal_interface(exp(1j.*(dec_symbs-1+1/2)*2*pi/4),p);
+
+%% BER TESTER
+sig_x     = Combiner_complex.traverse(sig_x_c.fun1(@(x) - x), sig_x_s.fun1(@(x) - x));
+T         = round((angle(get(sig_x))-(pi/4))/(pi/2));
+sig_diff  = uint16(mod(T(2:end)-T(1:(end-1)),4))+1; 
+sig_bits  = Combiner_simple.traverse(sig_x_c.fun1(@(x) - x), sig_x_s.fun1(@(x) - x));
+bits = get(sig_bits);
+bits(bits==-1) =0;
+symbs = uint16(mod(T,4))+1;
+
+param.bert = struct('M', M, 'dimensions', 1,'ConstType','QAM', 'coding', 'bin', 'PostProcessMethod', 'none','DecisionType', 'hard');
+param.bert_prbs = struct('M', M, 'dimensions', 1,'ConstType','QAM', 'coding', 'bin','prbs', gen_prbs(15),'PostProcessMethod', 'none','DecisionType', 'hard');
+bert = BERT_v1(param.bert);
+bert_prbs = BERT_v1(param.bert_prbs);
+
+IQ = Combiner_complex.traverse(decimator.traverse(I), decimator.traverse(Q));
+
+phase_noise = zeros(L,1);
+% Center elements of each block of size 2*N+1.
+blck_indx_vec =  (1:cpr.n_blcks)*(2*cpr.N+1)-cpr.N; 
+blck_indx = 1;
+for blck_cntr = blck_indx_vec
+    blck = (blck_cntr-cpr.N):(blck_cntr+cpr.N);
+    phase_noise(blck) = cpr.phase_x(blck_indx);
+    blck_indx = blck_indx+1;
+end
+
+bert_prbs.traverse(IQ);
+name = [get(gcf,'name'),': Before phase correction'];
+set(gcf,'name',name)
+
+IQ = signal_interface(IQ.getRaw.*exp(-1j*phase_noise),p);
+
+lut  = [4,3,1,2];
+[~,symb_range] = findrange(sig_diff);
+for i=max(1,symb_range.min):symb_range.max
+    idx = sig_diff==i; % Find indices for all symbols i
+    symb(idx) = repmat(lut(i),1,nnz(idx)); % Take value from the LUT
+end
+symb = uint16(symb);
+bert.traverse(decoded_IQ,symb');
+name = [get(gcf,'name'),': After phase correction using symbs'];
+set(gcf,'name',name)
+
+bert_prbs.traverse(IQ);
+bert_prbs.traverse(decoded_IQ);
+name = [get(gcf,'name'),': After phase correction using PRBS'];
+set(gcf,'name',name)
+
+


### PR DESCRIPTION
I have added a module for carrier phase recovery and an example script
that tests the module using a simple single polarization coherent link.
This required the addition of blocks that simplify traditional
polarization multiplexed functions such as the coherent front_end and
the IQ modulator.